### PR TITLE
Add `data-symbol` to SVG wrapper for ease of use with CSS.

### DIFF
--- a/src/runtime/components/SpriteSymbol.ts
+++ b/src/runtime/components/SpriteSymbol.ts
@@ -28,6 +28,7 @@ export default defineComponent({
             'svg',
             {
               xmlns: 'http://www.w3.org/2000/svg',
+              'data-symbol': (name || sprite),
             },
             use,
           )


### PR DESCRIPTION
Adds `data-symbol` to the SVG wrapper for easy handling with CSS since a selector with `:has()`, the use tag and the href attribute adds unnecessary complexity. Omitted for the wrapper-less alternative, the user is expected to handle the SVG tag themselves in this case.