### PR TITLE
Replace hardcoded buildAssetsPath wuth value from the nuxt config

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -102,7 +102,8 @@ export default defineNuxtModule<ModuleOptions>({
       // Add the template for the SVG sprite.
       addTemplate({
         filename:
-          'dist/client/_nuxt/' +
+          'dist/client' +
+          nuxt.options.app.buildAssetsDir +
           getSpriteFileName(key, context[key]?.hash, DEV),
         write: true,
         options: {
@@ -127,7 +128,12 @@ export default defineNuxtModule<ModuleOptions>({
         nuxtSvgSprite: true,
       },
       getContents: () => {
-        return buildRuntimeTemplate(context, DEV, runtimeOptions)
+        return buildRuntimeTemplate(
+          context,
+          DEV,
+          runtimeOptions,
+          nuxt.options.app.buildAssetsDir,
+        )
       },
     })
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -186,6 +186,7 @@ export function buildRuntimeTemplate(
   context: ModuleContext,
   isDev: boolean,
   options: RuntimeOptions,
+  path: string,
 ) {
   const spriteKeys = Object.keys(context)
   const type = spriteKeys
@@ -210,7 +211,7 @@ export function buildRuntimeTemplate(
       if (isDev) {
         name += '?t=' + Date.now()
       }
-      acc[key] = '/_nuxt/' + name
+      acc[key] = path + name
     }
     return acc
   }, {})


### PR DESCRIPTION
Replacing the hardcoded value with the `buildAssetsDir` parameter from the Nuxt config prevents SVG images from disappearing when the value is not default.